### PR TITLE
Dev connector srv

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -43,7 +43,7 @@ ENV I2B2_HIVE_URL=http://i2b2:8080/i2b2/services \
     MC_DB_PORT=5432 \
     MC_DB_USER=medcoconnector \
     MC_DB_PW=medcoconnector \
-    MC_DB_NAME=medcoconnector
+    MC_DB_NAME=medcoconnectorsrv
 
 EXPOSE 1999
 ENTRYPOINT docker-entrypoint.sh medco-connector-server --write-timeout=${SERVER_HTTP_WRITE_TIMEOUT_SECONDS}s

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -39,11 +39,11 @@ ENV I2B2_HIVE_URL=http://i2b2:8080/i2b2/services \
     MEDCO_NODES_URL="http://medco-connector-srv0/medco,http://medco-connector-srv1/medco,http://medco-connector-srv2/medco" \
     MEDCO_NODE_IDX=0 \
     MEDCO_OBFUSCATION_MIN=5 \
-    GA_DB_HOST=postgresql \
-    GA_DB_PORT=5432 \
-    GA_DB_USER=genomicannotations \
-    GA_DB_PW=genomicannotations \
-    GA_DB_NAME=gamedcosrv
+    MC_DB_HOST=postgresql \
+    MC_DB_PORT=5432 \
+    MC_DB_USER=medcoconnector \
+    MC_DB_PW=medcoconnector \
+    MC_DB_NAME=medcoconnector
 
 EXPOSE 1999
 ENTRYPOINT docker-entrypoint.sh medco-connector-server --write-timeout=${SERVER_HTTP_WRITE_TIMEOUT_SECONDS}s

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -26,11 +26,11 @@ services:
       - MEDCO_OBFUSCATION_MIN=5
       - MEDCO_NODES_URL=http://medco-connector-srv0/medco,http://medco-connector-srv1/medco,http://medco-connector-srv2/medco
       - MEDCO_NODE_IDX=0
-      - GA_DB_HOST=postgresql
-      - GA_DB_PORT=5432
-      - GA_DB_USER=genomicannotations
-      - GA_DB_PW=genomicannotations
-      - GA_DB_NAME=gamedcosrv
+      - MC_DB_HOST=postgresql
+      - MC_DB_PORT=5432
+      - MC_DB_USER=medcoconnector
+      - MC_DB_PW=medcoconnector
+      - MC_DB_NAME=mcsrv
     volumes:
       - ./configuration-profile:/medco-configuration
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - MC_DB_PORT=5432
       - MC_DB_USER=medcoconnector
       - MC_DB_PW=medcoconnector
-      - MC_DB_NAME=mcsrv
+      - MC_DB_NAME=medcoconnectorsrv
     volumes:
       - ./configuration-profile:/medco-configuration
 

--- a/deployment/docker-entrypoint.sh
+++ b/deployment/docker-entrypoint.sh
@@ -9,22 +9,23 @@ if [[ `ls -1 /medco-configuration/srv*-certificate.crt 2>/dev/null | wc -l` != 0
 fi
 
 # wait for postgres to be available
-export PGPASSWORD="$GA_DB_PW"
-export PSQL_PARAMS="-v ON_ERROR_STOP=1 -h ${GA_DB_HOST} -p ${GA_DB_PORT} -U ${GA_DB_USER}"
+export PGPASSWORD="$MC_DB_PW"
+export PSQL_PARAMS="-v ON_ERROR_STOP=1 -h ${MC_DB_HOST} -p ${MC_DB_PORT} -U ${MC_DB_USER}"
 until psql $PSQL_PARAMS -d postgres -c '\q'; do
   >&2 echo "Waiting for postgresql..."
   sleep 1
 done
 
 # initialize database if it does not exist (credentials must be valid and have create database right)
-DB_CHECK=$(psql ${PSQL_PARAMS} -d postgres -X -A -t -c "select count(*) from pg_database where datname = '${GA_DB_NAME}';")
+DB_CHECK=$(psql ${PSQL_PARAMS} -d postgres -X -A -t -c "select count(*) from pg_database where datname = '${MC_DB_NAME}';")
 if [[ "$DB_CHECK" -ne "1" ]]; then
-echo "Initialising genomic_annotations database"
-    psql $PSQL_PARAMS -d postgres <<-EOSQL
-        CREATE DATABASE ${GA_DB_NAME};
+echo "Initialising medco connector database"
+psql $PSQL_PARAMS -d postgres <<-EOSQL
+    CREATE DATABASE ${MC_DB_NAME};
 EOSQL
-psql $PSQL_PARAMS -d "$GA_DB_NAME" <<-EOSQL
-        CREATE SCHEMA genomic_annotations;
+psql $PSQL_PARAMS -d "$MC_DB_NAME" <<-EOSQL
+      CREATE SCHEMA genomic_annotations;
+      CREATE SCHEMA query_tools;
 EOSQL
 fi
 fi

--- a/util/server/configuration.go
+++ b/util/server/configuration.go
@@ -2,12 +2,13 @@ package utilserver
 
 import (
 	"database/sql"
-	"github.com/sirupsen/logrus"
-	onetLog "go.dedis.ch/onet/v3/log"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	onetLog "go.dedis.ch/onet/v3/log"
 )
 
 // LogLevel is the log level, assuming the same convention as the cothority / unlynx log levels:
@@ -121,12 +122,12 @@ func init() {
 	}
 	MedCoObfuscationMin = int(obf)
 
-	DBHost = os.Getenv("GA_DB_HOST")
-	DBName = os.Getenv("GA_DB_NAME")
-	DBLoginUser = os.Getenv("GA_DB_USER")
-	DBLoginPassword = os.Getenv("GA_DB_PW")
+	DBHost = os.Getenv("MC_DB_HOST")
+	DBName = os.Getenv("MC_DB_NAME")
+	DBLoginUser = os.Getenv("MC_DB_USER")
+	DBLoginPassword = os.Getenv("MC_DB_PW")
 
-	dbPort, err := strconv.ParseInt(os.Getenv("GA_DB_PORT"), 10, 64)
+	dbPort, err := strconv.ParseInt(os.Getenv("MC_DB_PORT"), 10, 64)
 	if err != nil || dbPort < 0 || dbPort > 65535 {
 		logrus.Warn("invalid DB port, defaulted")
 		dbPort = 5432


### PR DESCRIPTION
As new schemata will be added to the medco connector database, genomicannotation postgres user and gamedcosrv database are renamed medcoconnector and medcoconnectorsrv respectively.

These names more generic and show the direct link between this DB and the medco connector.

The renamed DB would store two schemata: genomic_annotations and query_tools