### PR TITLE
set blob option to "true" in get modifier children

### DIFF
--- a/connector/wrappers/i2b2/ontology_models.go
+++ b/connector/wrappers/i2b2/ontology_models.go
@@ -77,7 +77,7 @@ func NewOntReqGetModifiersMessageBody(self string) Request {
 func NewOntReqGetModifierChildrenMessageBody(parent, appliedPath, appliedConcept string) Request {
 	body := OntReqGetModifierChildrenMessageBody{}
 
-	body.GetModifierChildren.Blob = "false"
+	body.GetModifierChildren.Blob = "true"
 	body.GetModifierChildren.Type = "limited"
 	body.GetModifierChildren.Max = "200"
 	body.GetModifierChildren.Synonyms = "false"


### PR DESCRIPTION
The blob option for get modifier children was set to false, so no xml metadata were returned.

This field has become important for processing data type. 