### PR TITLE
missing blob set to "true" for get_modifiers

### DIFF
--- a/connector/wrappers/i2b2/ontology_models.go
+++ b/connector/wrappers/i2b2/ontology_models.go
@@ -65,6 +65,7 @@ func NewOntReqGetChildrenMessageBody(parent string) Request {
 func NewOntReqGetModifiersMessageBody(self string) Request {
 	body := OntReqGetModifiersMessageBody{}
 
+	body.GetModifiers.Blob = "true"
 	body.GetModifiers.Hiddens = "false"
 	body.GetModifiers.Synonyms = "false"
 


### PR DESCRIPTION
A definition was missing for modifiers and value metadata xml was not sent back as default flag is set to false.