### PR TITLE
fixed the table case, and the patientlist intersection

### DIFF
--- a/connector/server/survivalanalysis/get_codes.go
+++ b/connector/server/survivalanalysis/get_codes.go
@@ -104,10 +104,9 @@ func getModifierCodes(path string, appliedPath string) ([]string, error) {
 // getTableName get the ontology table name for a given table code (in I2B2, the first node ofa URI is the table CD)
 // getTableName returns an error when no entry was found for the provided table code.
 func getTableName(tableCD string) (string, error) {
-	upper := strings.ToUpper(tableCD)
-	description := fmt.Sprintf("getTableName (table code: %s), procedure: %s", upper, "medco_ont.table_name")
+	description := fmt.Sprintf("getTableName (table code: %s), procedure: %s", tableCD, "medco_ont.table_name")
 	logrus.Debugf("runnig: %s", description)
-	row := utilserver.I2B2DBConnection.QueryRow("SELECT medco_ont.table_name($1);", upper)
+	row := utilserver.I2B2DBConnection.QueryRow("SELECT medco_ont.table_name($1);", tableCD)
 	ret := new(string)
 	err := row.Scan(ret)
 	if err != nil {

--- a/connector/server/survivalanalysis/get_codes.go
+++ b/connector/server/survivalanalysis/get_codes.go
@@ -105,16 +105,16 @@ func getModifierCodes(path string, appliedPath string) ([]string, error) {
 // getTableName returns an error when no entry was found for the provided table code.
 func getTableName(tableCD string) (string, error) {
 	description := fmt.Sprintf("getTableName (table code: %s), procedure: %s", tableCD, "medco_ont.table_name")
-	logrus.Debugf("runnig: %s", description)
+	logrus.Debugf("querying the name of the ontology table for the code embedded in I2B2 item definition: %s", description)
 	row := utilserver.I2B2DBConnection.QueryRow("SELECT medco_ont.table_name($1);", tableCD)
 	ret := new(string)
 	err := row.Scan(ret)
 	if err != nil {
-		err = fmt.Errorf("while getting table name: %s, DB operation: %s", err.Error(), description)
+		err = fmt.Errorf("while getting ontology table name: %s, DB operation: %s", err.Error(), description)
 		logrus.Error(err)
 		return "", err
 	}
-	logrus.Debugf(`successfully selected table name "%s", DB operation: %s`, *ret, description)
+	logrus.Debugf(`successfully ontology table name "%s", DB operation: %s`, *ret, description)
 
 	return strings.ToLower(*ret), nil
 }

--- a/connector/server/survivalanalysis/get_codes.go
+++ b/connector/server/survivalanalysis/get_codes.go
@@ -101,7 +101,7 @@ func getModifierCodes(path string, appliedPath string) ([]string, error) {
 	return res, nil
 }
 
-// getTableName get the ontology table name for a given table code (in I2B2, the first node ofa URI is the table CD)
+// getTableName get the ontology table name for a given table code (in I2B2, the first node of a URI is the table CD)
 // getTableName returns an error when no entry was found for the provided table code.
 func getTableName(tableCD string) (string, error) {
 	description := fmt.Sprintf("getTableName (table code: %s), procedure: %s", tableCD, "medco_ont.table_name")

--- a/connector/server/survivalanalysis/get_codes_test.go
+++ b/connector/server/survivalanalysis/get_codes_test.go
@@ -23,10 +23,6 @@ func TestGetTableName(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expected, res)
 
-	res, err = getTableName("sPhN")
-	assert.NoError(t, err)
-	assert.Equal(t, expected, res)
-
 	_, err = getTableName("this table does not exist")
 	assert.Error(t, err)
 }
@@ -45,10 +41,6 @@ func TestGetCodes(t *testing.T) {
 	assert.ElementsMatch(t, expectedList, res)
 
 	res, err = getConceptCodes("/E2ETEST/e2etest")
-	assert.NoError(t, err)
-	assert.ElementsMatch(t, expectedList, res)
-
-	res, err = getConceptCodes("/e2etest/e2etest")
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, expectedList, res)
 

--- a/connector/server/survivalanalysis/sub_group_explore.go
+++ b/connector/server/survivalanalysis/sub_group_explore.go
@@ -8,31 +8,28 @@ import (
 )
 
 // SubGroupExplore executes an I2B2 Explore query with panels
-func SubGroupExplore(queryName string, subGroupIndex int, panels []*models.Panel) (int64, []int64, error) {
+func SubGroupExplore(queryName string, subGroupIndex int, panels []*models.Panel) ([]int64, error) {
 
-	patientCount, patientSetID, err := i2b2.ExecutePsmQuery(queryName+"_SUBGROUP_"+strconv.Itoa(subGroupIndex), panels, "ANY")
+	_, patientSetID, err := i2b2.ExecutePsmQuery(queryName+"_SUBGROUP_"+strconv.Itoa(subGroupIndex), panels, "ANY")
 	if err != nil {
-		return 0, nil, err
+		return nil, err
 	}
 	patientIDs, _, err := i2b2.GetPatientSet(patientSetID, false)
 	if err != nil {
-		return 0, nil, err
+		return nil, err
 	}
-	pCount, err := strconv.ParseInt(patientCount, 10, 64)
-	if err != nil {
-		return 0, nil, err
-	}
+
 	pIDs := make([]int64, len(patientIDs))
 
 	for i, pID := range patientIDs {
 		id, err := strconv.ParseInt(pID, 10, 64)
 		if err != nil {
-			return 0, nil, err
+			return nil, err
 		}
 		pIDs[i] = id
 	}
 
-	return pCount, pIDs, nil
+	return pIDs, nil
 
 }
 

--- a/connector/server/survivalanalysis/survival_query.go
+++ b/connector/server/survivalanalysis/survival_query.go
@@ -146,7 +146,7 @@ func (q *Query) Execute() error {
 			timer = time.Now()
 			logrus.Infof("I2B2 explore for subgroup %d", i)
 			logrus.Tracef("panels %+v", panels)
-			initialCount, patientList, err := SubGroupExplore(q.QueryName, i, panels)
+			_, patientList, err := SubGroupExplore(q.QueryName, i, panels)
 			if err != nil {
 				logrus.Errorf("during subgroup explore procedure: %s", err.Error())
 				err = fmt.Errorf("during subgroup explore procedure")
@@ -156,6 +156,7 @@ func (q *Query) Execute() error {
 			logrus.Infof("successful I2B2 explore query %d", i)
 			timers.AddTimers(fmt.Sprintf("medco-connector-i2b2-query-group%d", i), timer, nil)
 			patientList = intersect(cohort, patientList)
+			initialCount := int64(len(patientList))
 			patientLists = append(patientLists, patientList)
 			initialCounts = append(initialCounts, initialCount)
 			logrus.Debugf("Initial Counts %v", initialCounts)

--- a/connector/server/survivalanalysis/survival_query.go
+++ b/connector/server/survivalanalysis/survival_query.go
@@ -146,7 +146,7 @@ func (q *Query) Execute() error {
 			timer = time.Now()
 			logrus.Infof("I2B2 explore for subgroup %d", i)
 			logrus.Tracef("panels %+v", panels)
-			_, patientList, err := SubGroupExplore(q.QueryName, i, panels)
+			patientList, err := SubGroupExplore(q.QueryName, i, panels)
 			if err != nil {
 				logrus.Errorf("during subgroup explore procedure: %s", err.Error())
 				err = fmt.Errorf("during subgroup explore procedure")


### PR DESCRIPTION
The initial count was made on the number of patient matching the start event concept, without intersecting the set with the saved cohort.

The case of table names was made upper, but it is case sensitive.