### PR TITLE
capitalized names of facttable_column in stored procedure + corrected swagger behaviour

### DIFF
--- a/build/package/i2b2/sql/75-stored-procedures/get_concept_codes.plpgsql
+++ b/build/package/i2b2/sql/75-stored-procedures/get_concept_codes.plpgsql
@@ -12,9 +12,9 @@ BEGIN
       'SELECT c_basecode
 	      FROM medco_ont.%I
 	      WHERE (c_basecode IS NOT NULL AND c_basecode != %L
-			    AND c_facttablecolumn = %L
+			    AND upper(c_facttablecolumn) = %L
 		      AND c_fullname LIKE $1);',
-      ontology, '', 'concept_cd'
+      ontology, '', 'CONCEPT_CD'
     )
     USING path;
   END;

--- a/build/package/i2b2/sql/75-stored-procedures/get_modifier_codes.plpgsql
+++ b/build/package/i2b2/sql/75-stored-procedures/get_modifier_codes.plpgsql
@@ -13,9 +13,9 @@ BEGIN
       'SELECT c_basecode
 	      FROM medco_ont.%I
 	      WHERE (c_basecode IS NOT NULL AND c_basecode != %L
-			    AND c_facttablecolumn = %L
+			    AND upper(c_facttablecolumn) = %L
 		      AND c_fullname LIKE $1 AND m_applied_path = $2);',
-      ontology, '', 'modifier_cd'
+      ontology, '', 'MODIFIER_CD'
     )
     USING path, applied_path;
   END;

--- a/connector/client/survivalanalysis/encrypted_results.go
+++ b/connector/client/survivalanalysis/encrypted_results.go
@@ -62,9 +62,9 @@ func encryptedResultsFromAPIResponse(bodyResults []*survival_analysis.SurvivalAn
 			}
 		}, len(group.GroupResults))
 		for j, timePoint := range group.GroupResults {
-			res[i].TimePoints[j].Time = int(timePoint.Timepoint)
-			res[i].TimePoints[j].EncryptedEvents.EventsOfInterest = timePoint.Events.Eventofinterest
-			res[i].TimePoints[j].EncryptedEvents.CensoringEvents = timePoint.Events.Censoringevent
+			res[i].TimePoints[j].Time = int(*timePoint.Timepoint)
+			res[i].TimePoints[j].EncryptedEvents.EventsOfInterest = *timePoint.Events.Eventofinterest
+			res[i].TimePoints[j].EncryptedEvents.CensoringEvents = *timePoint.Events.Censoringevent
 		}
 	}
 	return res

--- a/connector/restapi/client/survival_analysis/survival_analysis_responses.go
+++ b/connector/restapi/client/survival_analysis/survival_analysis_responses.go
@@ -879,10 +879,12 @@ swagger:model SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0
 type SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0 struct {
 
 	// events
-	Events *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events `json:"events,omitempty"`
+	// Required: true
+	Events *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events `json:"events"`
 
 	// timepoint
-	Timepoint int64 `json:"timepoint,omitempty"`
+	// Required: true
+	Timepoint *int64 `json:"timepoint"`
 }
 
 // Validate validates this survival analysis o k body results items0 group results items0
@@ -890,6 +892,10 @@ func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0) Validate(formats
 	var res []error
 
 	if err := o.validateEvents(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateTimepoint(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -901,8 +907,8 @@ func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0) Validate(formats
 
 func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0) validateEvents(formats strfmt.Registry) error {
 
-	if swag.IsZero(o.Events) { // not required
-		return nil
+	if err := validate.Required("events", "body", o.Events); err != nil {
+		return err
 	}
 
 	if o.Events != nil {
@@ -912,6 +918,15 @@ func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0) validateEvents(f
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0) validateTimepoint(formats strfmt.Registry) error {
+
+	if err := validate.Required("timepoint", "body", o.Timepoint); err != nil {
+		return err
 	}
 
 	return nil
@@ -941,14 +956,47 @@ swagger:model SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events
 type SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events struct {
 
 	// censoringevent
-	Censoringevent string `json:"censoringevent,omitempty"`
+	// Required: true
+	Censoringevent *string `json:"censoringevent"`
 
 	// eventofinterest
-	Eventofinterest string `json:"eventofinterest,omitempty"`
+	// Required: true
+	Eventofinterest *string `json:"eventofinterest"`
 }
 
 // Validate validates this survival analysis o k body results items0 group results items0 events
 func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateCensoringevent(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateEventofinterest(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events) validateCensoringevent(formats strfmt.Registry) error {
+
+	if err := validate.Required("events"+"."+"censoringevent", "body", o.Censoringevent); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events) validateEventofinterest(formats strfmt.Registry) error {
+
+	if err := validate.Required("events"+"."+"eventofinterest", "body", o.Eventofinterest); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/connector/restapi/server/embedded_spec.go
+++ b/connector/restapi/server/embedded_spec.go
@@ -847,7 +847,7 @@ func init() {
                 }
               },
               "operator": {
-                "description": "# NUMBER operators EQ: equals NE: not equals GT: greater than GE: greater than or equal LT: less than LE: less than or equal BETWEEN: between (value syntax: \"x and y\")\n# TEXT operators IN: in (value syntax: \"'x','y','z'\") LIKE[exact]: equal LIKE[begin]: begins with LIKE[end]: ends with LIKE[contains]: contains\n",
+                "description": "# NUMBER operators EQ: equal NE: not equal GT: greater than GE: greater than or equal LT: less than LE: less than or equal BETWEEN: between (value syntax: \"x and y\") # TEXT operators IN: in (value syntax: \"'x','y','z'\") LIKE[exact]: equal LIKE[begin]: begins with LIKE[end]: ends with LIKE[contains]: contains\n",
                 "type": "string",
                 "enum": [
                   "EQ",
@@ -1387,9 +1387,17 @@ func init() {
                   "type": "array",
                   "items": {
                     "type": "object",
+                    "required": [
+                      "timepoint",
+                      "events"
+                    ],
                     "properties": {
                       "events": {
                         "type": "object",
+                        "required": [
+                          "eventofinterest",
+                          "censoringevent"
+                        ],
                         "properties": {
                           "censoringevent": {
                             "type": "string"
@@ -2658,7 +2666,7 @@ func init() {
           }
         },
         "operator": {
-          "description": "# NUMBER operators EQ: equals NE: not equals GT: greater than GE: greater than or equal LT: less than LE: less than or equal BETWEEN: between (value syntax: \"x and y\")\n# TEXT operators IN: in (value syntax: \"'x','y','z'\") LIKE[exact]: equal LIKE[begin]: begins with LIKE[end]: ends with LIKE[contains]: contains\n",
+          "description": "# NUMBER operators EQ: equal NE: not equal GT: greater than GE: greater than or equal LT: less than LE: less than or equal BETWEEN: between (value syntax: \"x and y\") # TEXT operators IN: in (value syntax: \"'x','y','z'\") LIKE[exact]: equal LIKE[begin]: begins with LIKE[end]: ends with LIKE[contains]: contains\n",
           "type": "string",
           "enum": [
             "EQ",
@@ -2727,9 +2735,17 @@ func init() {
     },
     "ResultsItems0GroupResultsItems0": {
       "type": "object",
+      "required": [
+        "timepoint",
+        "events"
+      ],
       "properties": {
         "events": {
           "type": "object",
+          "required": [
+            "eventofinterest",
+            "censoringevent"
+          ],
           "properties": {
             "censoringevent": {
               "type": "string"
@@ -2746,6 +2762,10 @@ func init() {
     },
     "ResultsItems0GroupResultsItems0Events": {
       "type": "object",
+      "required": [
+        "eventofinterest",
+        "censoringevent"
+      ],
       "properties": {
         "censoringevent": {
           "type": "string"
@@ -3600,9 +3620,17 @@ func init() {
                   "type": "array",
                   "items": {
                     "type": "object",
+                    "required": [
+                      "timepoint",
+                      "events"
+                    ],
                     "properties": {
                       "events": {
                         "type": "object",
+                        "required": [
+                          "eventofinterest",
+                          "censoringevent"
+                        ],
                         "properties": {
                           "censoringevent": {
                             "type": "string"

--- a/connector/restapi/server/operations/survival_analysis/survival_analysis.go
+++ b/connector/restapi/server/operations/survival_analysis/survival_analysis.go
@@ -758,10 +758,12 @@ func (o *SurvivalAnalysisOKBodyResultsItems0) UnmarshalBinary(b []byte) error {
 type SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0 struct {
 
 	// events
-	Events *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events `json:"events,omitempty"`
+	// Required: true
+	Events *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events `json:"events"`
 
 	// timepoint
-	Timepoint int64 `json:"timepoint,omitempty"`
+	// Required: true
+	Timepoint *int64 `json:"timepoint"`
 }
 
 // Validate validates this survival analysis o k body results items0 group results items0
@@ -769,6 +771,10 @@ func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0) Validate(formats
 	var res []error
 
 	if err := o.validateEvents(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateTimepoint(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -780,8 +786,8 @@ func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0) Validate(formats
 
 func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0) validateEvents(formats strfmt.Registry) error {
 
-	if swag.IsZero(o.Events) { // not required
-		return nil
+	if err := validate.Required("events", "body", o.Events); err != nil {
+		return err
 	}
 
 	if o.Events != nil {
@@ -791,6 +797,15 @@ func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0) validateEvents(f
 			}
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0) validateTimepoint(formats strfmt.Registry) error {
+
+	if err := validate.Required("timepoint", "body", o.Timepoint); err != nil {
+		return err
 	}
 
 	return nil
@@ -820,14 +835,47 @@ func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0) UnmarshalBinary(
 type SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events struct {
 
 	// censoringevent
-	Censoringevent string `json:"censoringevent,omitempty"`
+	// Required: true
+	Censoringevent *string `json:"censoringevent"`
 
 	// eventofinterest
-	Eventofinterest string `json:"eventofinterest,omitempty"`
+	// Required: true
+	Eventofinterest *string `json:"eventofinterest"`
 }
 
 // Validate validates this survival analysis o k body results items0 group results items0 events
 func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateCensoringevent(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateEventofinterest(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events) validateCensoringevent(formats strfmt.Registry) error {
+
+	if err := validate.Required("events"+"."+"censoringevent", "body", o.Censoringevent); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events) validateEventofinterest(formats strfmt.Registry) error {
+
+	if err := validate.Required("events"+"."+"eventofinterest", "body", o.Eventofinterest); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/connector/server/handlers/survival_analysis.go
+++ b/connector/server/handlers/survival_analysis.go
@@ -75,10 +75,18 @@ func MedCoSurvivalAnalysisHandler(param survival_analysis.SurvivalAnalysisParams
 
 		timePoints := make([]*survival_analysis.SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0, 0)
 		for _, timePoint := range group.TimePointResults {
-			timePoints = append(timePoints, &survival_analysis.SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0{Timepoint: int64(timePoint.TimePoint),
+			timeValue := new(int64)
+			eventOfInterest := new(string)
+			censoringEvent := new(string)
+
+			*timeValue = int64(timePoint.TimePoint)
+			*eventOfInterest = timePoint.Result.EventValueAgg
+			*censoringEvent = timePoint.Result.CensoringValueAgg
+
+			timePoints = append(timePoints, &survival_analysis.SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0{Timepoint: timeValue,
 				Events: &survival_analysis.SurvivalAnalysisOKBodyResultsItems0GroupResultsItems0Events{
-					Eventofinterest: timePoint.Result.EventValueAgg,
-					Censoringevent:  timePoint.Result.CensoringValueAgg,
+					Eventofinterest: eventOfInterest,
+					Censoringevent:  censoringEvent,
 				}})
 		}
 		resultList = append(resultList, &survival_analysis.SurvivalAnalysisOKBodyResultsItems0{

--- a/connector/swagger/medco-connector.yml
+++ b/connector/swagger/medco-connector.yml
@@ -686,6 +686,12 @@ responses:
                           type: "string"
                         censoringevent:
                           type: "string"
+                      required:
+                        - eventofinterest
+                        - censoringevent
+                  required:
+                    - timepoint
+                    - events
         timers:
           $ref: "#/definitions/timers"
 


### PR DESCRIPTION
Swagger considered numerical 0 as undefined in response bodies, which was solved by qualifying the fields as required

In E2E test column are in lower case, however in deployed test data, these are in upper case. Stored procedures for getting concept and modifier codes are now agnostic of that.