### PR TITLE
add missing build tags in some test files

### DIFF
--- a/connector/client/survivalanalysis/encrypted_results_test.go
+++ b/connector/client/survivalanalysis/encrypted_results_test.go
@@ -1,3 +1,5 @@
+// +build unit_test
+
 package survivalclient
 
 import (

--- a/connector/client/survivalanalysis/parameters_test.go
+++ b/connector/client/survivalanalysis/parameters_test.go
@@ -1,3 +1,5 @@
+// +build unit_test
+
 package survivalclient
 
 import (

--- a/connector/models/timepoints_test.go
+++ b/connector/models/timepoints_test.go
@@ -1,3 +1,5 @@
+// +build unit_test
+
 package medcomodels
 
 import (


### PR DESCRIPTION
reminder to include the build tags in test files so that they are executed at the right time (the missing ones were executed twice)