### PR TITLE
corrected a documentation string

### DIFF
--- a/cmd/medco-cli-client/main.go
+++ b/cmd/medco-cli-client/main.go
@@ -168,7 +168,7 @@ func main() {
 		// cli.IntSlice produces wrong results
 		cli.StringFlag{
 			Name:     "cohortName, c",
-			Usage:    "Name of the new cohort",
+			Usage:    "Name of the cohort to remove",
 			Required: true,
 		},
 	}


### PR DESCRIPTION
In remove-saved-cohorts documentation. Replaced documentation string "Name of the new cohort" to "Name of the cohort to remove"