### PR TITLE
fix go version of runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.14'
+          go-version: '1.14'
       - run: go version
 
       - name: Checkout code


### PR DESCRIPTION
changed runner version from ^1.14 to 1.14, because it would take 1.17 otherwise and messes up with // +build lines in test files.