### PR TITLE
Allow saving cohorts for all users

### DIFF
--- a/connector/server/explore/explore_query_logic.go
+++ b/connector/server/explore/explore_query_logic.go
@@ -197,15 +197,17 @@ func (q *ExploreQuery) Execute(queryType ExploreQueryType) (err error) {
 			q.Result.EncPatientList = ksMaskedPatientIDs
 			logrus.Info(q.ID, ": key switched patient IDs")
 		}
-		q.Result.QueryID = queryID
-
-		logrus.Info(q.ID, ": patient set ID requested")
-
-		q.Result.PatientSetID, err = strconv.Atoi(patientSetID)
-		if err != nil {
-			return fmt.Errorf("while parsing patient set id: %v", err)
-		}
 	}
+
+	q.Result.QueryID = queryID
+
+	logrus.Info(q.ID, ": patient set ID requested")
+
+	q.Result.PatientSetID, err = strconv.Atoi(patientSetID)
+	if err != nil {
+		return fmt.Errorf("while parsing patient set id: %v", err)
+	}
+
 	//update medco connector result instance
 	timer = time.Now()
 	err = updateResultInstanceTable(queryID, patientCount, patientIDs, patientSetID)


### PR DESCRIPTION
The idea is simple. Allowing all users to save cohorts. 

Goes hand in hand with [this PR](https://github.com/ldsec/glowing-bear-medco/pull/230).

Some constraints disallowed it in the current state of the dev branch. If the user has no rights to see the patient list this was impossible for the user to save a cohort from an explore query.

The submitted solution allows users without the right to visualize and download the patient list to save the cohort. When an explore query returns, the query id of the explore query saved in the medco connector database is returned by the backend. This query id is then usable as a mean to identify the cohort to save when the user presses the save cohort button. 